### PR TITLE
Update quadrotor_sensors.urdf.xacro

### DIFF
--- a/thinc_sim_gazebo/urdf/quadrotor_sensors.urdf.xacro
+++ b/thinc_sim_gazebo/urdf/quadrotor_sensors.urdf.xacro
@@ -31,13 +31,13 @@ xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
     <!-- The following two cameras should be united to one! -->
     <!-- Forward facing camera -->
     <xacro:include filename="$(find thinc_sim_gazebo)/urdf/sensors/generic_camera.urdf.xacro" />
-    <xacro:generic_camera name="front" sim_name="ardrone" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
+    <xacro:generic_camera name="front" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
       <origin xyz="0.21 0.0 0.01" rpy="0 0 0"/>
     </xacro:generic_camera>
 
     <!-- Downward facing camera -->
     <xacro:include filename="$(find thinc_sim_gazebo)/urdf/sensors/generic_camera.urdf.xacro" />
-    <xacro:generic_camera name="bottom" sim_name="ardrone" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
+    <xacro:generic_camera name="bottom" parent="base_link" update_rate="60" res_x="640" res_y="360" image_format="R8G8B8" hfov="${81*M_PI/180}">
       <origin xyz="0.15 0.0 0.0" rpy="0 ${M_PI/2} 0"/>
     </xacro:generic_camera>
     


### PR DESCRIPTION
Deleted sim_name="ardrone" twice (invalid parameter)
These parameters throw a xacro.XacroException: Invalid parameter "sim_name" while expanding macro "xacro:generic_camera".
The simulator works without them.
